### PR TITLE
fix: display midday booking as "12:00 pm" not "0:00 pm"

### DIFF
--- a/pages/api/bookings/index.js
+++ b/pages/api/bookings/index.js
@@ -264,7 +264,7 @@ export default catchErrorsFrom(async (req, res) => {
             }).format(datetime),
             time_long: new Intl.DateTimeFormat("en-GB", {
               hour: "numeric",
-              hour12: true,
+              hourCycle: "h12",
               minute: "2-digit",
               timeZone: "Europe/London",
             }).format(datetime),


### PR DESCRIPTION
fixes #9